### PR TITLE
Avoid -Werror=format-security failures.

### DIFF
--- a/lib/core/src/perl/RefHash.xs
+++ b/lib/core/src/perl/RefHash.xs
@@ -92,7 +92,7 @@ SV* ref2key(SV *keysv, tmp_keysv *tmp_key)
    }                                                                    \
 } STMT_END
 
-static char err_ref[]="Reference as a key in a normal hash";
+static const char err_ref[]="Reference as a key in a normal hash";
 
 static inline
 int ref_key_allowed(HV* class)


### PR DESCRIPTION
Simple change to fix compile issues when using the -Werror=format-security flag (Fedora does this by default now).
